### PR TITLE
feat(macro): add debug macro with write profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 
 # Mis
 *.log
+
+.idea/**
+rsprofile.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,18 +936,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392a54546fda6b7cc663379d0e6ce8b324cf88aecc5a499838e1be9781bdce2e"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1337,12 +1337,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "speedy-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "speedy-napi"
 version = "0.1.0"
 dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "serde",
+ "serde_json",
+ "speedy-macro",
  "speedy-transform",
 ]
 
@@ -1351,7 +1364,9 @@ name = "speedy-transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "serde",
  "serde_json",
+ "speedy-macro",
  "swc",
  "swc_atoms",
  "swc_common",
@@ -2110,9 +2125,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/core/speedy-macro/Cargo.toml
+++ b/core/speedy-macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "speedy-macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+serde_json = "1.0.71"
+serde = "1.0.132"
+regex = "1.5.4"
+proc-macro2 = "1.0"

--- a/core/speedy-macro/src/lib.rs
+++ b/core/speedy-macro/src/lib.rs
@@ -1,0 +1,142 @@
+extern crate proc_macro;
+
+use proc_macro::*;
+use std::string::String;
+
+#[proc_macro_attribute]
+pub fn speedydebugtest(_args: TokenStream, input: TokenStream) -> TokenStream {
+  println!("final:{:#?}", input.to_string());
+  input.to_string().parse().unwrap()
+}
+
+#[proc_macro_attribute]
+pub fn speedydebug(_args: TokenStream, input: TokenStream) -> TokenStream {
+  let res_tuple = rs_fn_parser(input.to_string().as_str());
+  // println!("item: \"{:#?}\"", res_tuple);
+  let args_str = res_tuple.1.clone();
+  let mut arg_var_name_list: Vec<String> = vec![];
+  args_str
+    .split(',')
+    .collect::<Vec<&str>>()
+    .into_iter()
+    .for_each(|kv| {
+      let varname = match kv.split(':').collect::<Vec<&str>>().get(0) {
+        Some(&name) => name,
+        _ => "",
+      };
+      if !varname.is_empty() {
+        arg_var_name_list.push("&".to_string() + varname.trim());
+      }
+    });
+
+  let mut fn_content = res_tuple.2.clone();
+  let macro_debug_content_template = "\
+  let needexec = {
+    let res = std::env::var(\"rsdebug\");
+    match res {
+        Ok(val) => {
+          if val == \"info\" {
+            true
+          } else {
+            false
+          }
+        }
+        _ => false,
+      }
+    };
+  if needexec {
+    let args = @@@;
+    let json_content = serde_json::to_string_pretty(&args).unwrap();
+    let profile_path = std::env::current_dir()
+                        .unwrap()
+                        .join(\"rsprofile.json\")
+                        .into_os_string()
+                        .into_string()
+                        .unwrap();
+    std::fs::write(profile_path.as_str(), json_content).unwrap();
+  }
+  ";
+  fn_content = macro_debug_content_template.replace(
+    "@@@",
+    format!("(\"{}\",{})", res_tuple.0, arg_var_name_list.join(",")).as_str(),
+  ) + fn_content.as_str();
+  let new_fn_str = format!(
+    "{} fn {}({}){}{}{}{}",
+    res_tuple.4, res_tuple.0, res_tuple.1, res_tuple.3, "{", fn_content, "}"
+  );
+
+  // println!("final:{:#?}", new_fn_str);
+  new_fn_str.parse().unwrap()
+}
+
+fn rs_fn_parser(str: &str) -> (String, String, String, String, String) {
+  let strtoarray = |str: &str| str.chars().map(|c| c.to_string()).collect::<Vec<String>>();
+  let ignore_lastchar = |str: &str| {
+    let mut chars = str.chars();
+    chars.next_back();
+    chars.as_str().to_string()
+  };
+  let intercept_str = drawstring(strtoarray(str).as_ref(), Some("fn"), Some("{"))
+    .trim()
+    .to_string();
+  let fn_name = drawstring(strtoarray(intercept_str.as_str()).as_ref(), None, Some("("))
+    .trim()
+    .to_string();
+  let args_str = drawstring(
+    strtoarray(intercept_str.as_str()).as_ref(),
+    Some("("),
+    Some(")"),
+  )
+  .trim()
+  .to_string();
+  let fn_content_str =
+    ignore_lastchar(drawstring(strtoarray(str).as_ref(), Some("{"), None).trim());
+  let mut res_str = drawstring(strtoarray(str).as_ref(), Some("->"), Some("{"))
+    .trim()
+    .to_string();
+  let macro_str = ignore_lastchar(drawstring(strtoarray(str).as_ref(), None, Some("fn")).trim());
+  if res_str.as_str() != "" {
+    res_str = " -> ".to_string() + res_str.as_str();
+  }
+  (fn_name, args_str, fn_content_str, res_str, macro_str)
+}
+
+fn drawstring(charlist: &[String], beginchar: Option<&str>, endchar: Option<&str>) -> String {
+  let mut sindex = 0;
+  let mut temp = "".to_string();
+  let mut handle_scan_context: Vec<String> = vec![];
+  let mut write_enable = false;
+  if beginchar.is_none() {
+    write_enable = true;
+  }
+  let safe_get = |list: &[String], index: usize| match list.get(index) {
+    Some(char) => char.to_string(),
+    _ => "".to_string(),
+  };
+
+  loop {
+    let char = safe_get(charlist, sindex);
+    temp += &char;
+    if sindex >= charlist.len() {
+      break;
+    }
+    if temp.as_str() != ""
+      && beginchar.is_some()
+      && temp.contains(beginchar.unwrap())
+      && !write_enable
+    {
+      temp = "".to_string();
+      write_enable = true;
+      sindex += 1;
+      continue;
+    }
+    if temp.as_str() != "" && endchar.is_some() && temp.contains(endchar.unwrap()) {
+      break;
+    }
+    if write_enable {
+      handle_scan_context.push(char.clone());
+    }
+    sindex += 1;
+  }
+  handle_scan_context.join("")
+}

--- a/core/speedy-transform/Cargo.toml
+++ b/core/speedy-transform/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 serde_json = "1.0.71"
+speedy-macro = { path = "../speedy-macro" }
+serde = "1.0.132"
 swc = "0.86.0"
 swc_ecma_parser = "0.78.7"
 swc_common = "0.14.6"

--- a/core/speedy-transform/src/test.rs
+++ b/core/speedy-transform/src/test.rs
@@ -1,7 +1,20 @@
 #[cfg(test)]
 pub mod tests {
+
   use crate::types::*;
   use crate::web_transform::parser::transform;
+
+  fn compare_handle(str: std::string::String) -> std::string::String {
+    let new_str = str.trim().replace("\n", "");
+    return new_str;
+  }
+
+  #[test]
+  fn env() {
+    for (key, val) in std::env::vars() {
+      println!("{:?} is {:?} ....", key, val);
+    }
+  }
 
   #[test]
   fn babel_import_test() {
@@ -111,7 +124,7 @@ import { throttle } from '@byted-growth/luckycat-util';
 
 const a = 123;
     ";
-    let _transfrom_res = transform(
+    let transfrom_res = transform(
       source,
       TransformConfig {
         react_runtime: Some(false),
@@ -149,6 +162,15 @@ const a = 123;
       Some("ES5".to_string()),
     )
     .unwrap();
-    println!(".........");
+    let target_code = "\
+import throttle from \"@byted-growth/luckycat-util/pure_es/throttle/index.js\";
+import Image from \"@byted-growth/luckycat-mobile/es/Image/index.js\";
+import { useState, useCallback, useEffect, Fragment } from 'react';
+const a = 123;
+    ";
+    assert_eq!(
+      compare_handle(transfrom_res.code),
+      compare_handle(target_code.to_string())
+    );
   }
 }

--- a/core/speedy-transform/src/types.rs
+++ b/core/speedy-transform/src/types.rs
@@ -1,24 +1,26 @@
-#[derive(Debug)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransformConfig {
   pub react_runtime: Option<bool>,
   pub babel_import: Option<Vec<BabelImportConfig>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BabelImportConfig {
   pub from_source: String,
   pub replace_css: Option<RepalceCssConfig>,
   pub replace_js: Option<RepalceSpecConfig>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RepalceSpecConfig {
   pub replace_expr: String,
   pub ignore_es_component: Option<Vec<String>>,
   pub lower: Option<bool>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RepalceCssConfig {
   pub ignore_style_component: Option<Vec<String>>,
   pub replace_expr: String,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,9 +10,12 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+serde_json = "1.0.71"
+serde = "1.0.132"
 napi = { version = "2.0.0", features = ["napi3"] }
 napi-derive = "2.0.0"
 speedy-transform = { path = "../core/speedy-transform" }
+speedy-macro = { path = "../core/speedy-macro" }
 
 [build-dependencies]
 napi-build = "1"

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -4,8 +4,9 @@ import {parse} from '@babel/parser';
 import traverse from '@babel/traverse';
 import generate from '@babel/generator';
 import {Program} from '@babel/types';
-
+import {execSync} from 'child_process';
 import {transform} from '../lib';
+import * as process from "process";
 
 describe('speedy_napi_cases', function speedyTest() {
     it('babel_import_transfrom', async () => {
@@ -55,8 +56,8 @@ class Page extends React.Component{
 
 ReactDOM.render(<Page / >, document.getElementById("root"));
         `;
-
         console.time('babel_import_swc_transfrom');
+        process.env["rsdebug"] = "info";
         const napi_res = transform.transformBabelImport(code, {
             reatRuntime: true,
             babelImport: [
@@ -79,6 +80,7 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
 
         // 执行同样的 babel 操作
         console.time('babel_import_babeljs_transfrom');
+
         const babel_res = babel_impl_bableimport(code, 'antd', `antd/es/{}/style/index.css`);
         console.timeEnd('babel_import_babeljs_transfrom');
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -2,12 +2,14 @@
 extern crate napi_derive;
 
 use napi::{Error, Result, Status};
+use speedy_macro::*;
 use speedy_transform::web_transform::parser::*;
 use types::*;
 
 mod test;
 mod types;
 
+#[speedydebug]
 #[napi]
 pub fn transform_babel_import(
   code: String,
@@ -16,65 +18,19 @@ pub fn transform_babel_import(
   target: Option<String>,
 ) -> Result<TransformOutput> {
   // 占位行...
-  let react_runtime = config.react_runtime;
-
-  let mut babel_import: Option<Vec<speedy_transform::types::BabelImportConfig>> = None;
-
-  if let Some(config) = config.babel_import {
-    babel_import = Some(
-      config
-        .into_iter()
-        .map(|c| {
-          let mut css: Option<speedy_transform::types::RepalceCssConfig> = None;
-          if c.replace_css.is_some() {
-            let mut ignore_style_component: Option<Vec<String>> = None;
-            let na_css = c.replace_css.as_ref().unwrap();
-            if na_css.ignore_style_component.is_some() {
-              ignore_style_component = na_css.ignore_style_component.clone();
-            }
-            css = Some(speedy_transform::types::RepalceCssConfig {
-              ignore_style_component,
-              replace_expr: na_css.replace_expr.clone(),
-              lower: na_css.lower,
-            });
-          }
-
-          let mut es: Option<speedy_transform::types::RepalceSpecConfig> = None;
-          if c.replace_js.is_some() {
-            let mut ignore_es_component: Option<Vec<String>> = None;
-            let na_js = c.replace_js.as_ref().unwrap();
-            if na_js.ignore_es_component.is_some() {
-              ignore_es_component = na_js.ignore_es_component.clone();
-            }
-            es = Some(speedy_transform::types::RepalceSpecConfig {
-              ignore_es_component,
-              replace_expr: na_js.replace_expr.clone(),
-              lower: na_js.lower,
-            });
-          }
-
-          speedy_transform::types::BabelImportConfig {
-            from_source: c.from_source,
-            replace_css: css,
-            replace_js: es,
-          }
-        })
-        .collect::<Vec<speedy_transform::types::BabelImportConfig>>(),
-    );
-  }
-
-  let rsconfig = speedy_transform::types::TransformConfig {
-    react_runtime,
-    babel_import,
-  };
-
-  let res = transform(code.as_str(), rsconfig, filename, target);
-
-  match res {
-    Ok(result) => Ok(TransformOutput {
-      code: result.code,
-      map: result.map,
-    }),
-    Err(msg) => Err(Error::new(Status::FunctionExpected, msg)),
+  let config_str = serde_json::to_string(&config).unwrap();
+  let rsconfig_res = serde_json::from_str::<speedy_transform::types::TransformConfig>(&config_str);
+  match rsconfig_res {
+    Ok(rsconfig) => {
+      let res = transform(code.as_str(), rsconfig, filename, target);
+      match res {
+        Ok(result) => Ok(TransformOutput {
+          code: result.code,
+          map: result.map,
+        }),
+        Err(msg) => Err(Error::new(Status::FunctionExpected, msg)),
+      }
+    }
+    Err(ex) => Err(Error::new(Status::InvalidArg, ex.to_string())),
   }
 }

--- a/node/src/test.rs
+++ b/node/src/test.rs
@@ -1,8 +1,22 @@
-#[cfg(test)]
 mod tests {
+  use speedy_macro::speedydebug;
+
   #[test]
   fn it_works() {
     let result = 2 + 2;
     assert_eq!(result, 4);
+  }
+
+  #[speedydebug]
+  fn debugmacro(num: i32, txt: &str) -> i32 {
+    println!("123,{},{}", num, txt);
+    num
+  }
+
+  #[test]
+  fn test() {
+    std::env::set_var("rsdebug", "info");
+    let c = debugmacro(1, "test6666");
+    print!("{}", c);
   }
 }

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[napi(object)]
 #[derive(Debug)]
 pub struct TransformOutput {
@@ -6,14 +8,14 @@ pub struct TransformOutput {
 }
 
 #[napi(object)]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransformConfig {
   pub react_runtime: Option<bool>,
   pub babel_import: Option<Vec<BabelImportConfig>>,
 }
 
 #[napi(object)]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BabelImportConfig {
   pub from_source: String,
   pub replace_css: Option<RepalceCssConfig>,
@@ -21,7 +23,7 @@ pub struct BabelImportConfig {
 }
 
 #[napi(object)]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RepalceSpecConfig {
   pub replace_expr: String,
   pub ignore_es_component: Option<Vec<String>>,
@@ -29,7 +31,7 @@ pub struct RepalceSpecConfig {
 }
 
 #[napi(object)]
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RepalceCssConfig {
   pub ignore_style_component: Option<Vec<String>>,
   pub replace_expr: String,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier . -w",
     "bench": "suno benchmark/bench.ts",
     "lint": "pnpm lint --dir node",
+    "build": "cd node && npm run build && cd -",
     "test": "mocha -r @swc-node/register node/__tests__/**/*.spec.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
1.   增加了原生调试宏
2.  增加了 napi 侧 参数 schema 复制到 core 核心参数 改为 json 序列化复制。
3.  node 侧 process.env["rsdebug"] = "info"; native 会启动 调试模式 落盘打印 宏 修饰函数 的参数。

