### PR TITLE
feat(speedy-transform): add camel2dash option and default option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1428,7 @@ name = "speedy-transform"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "heck",
  "napi",
  "napi-derive",
  "regex",

--- a/crates/speedy-transform/Cargo.toml
+++ b/crates/speedy-transform/Cargo.toml
@@ -23,4 +23,5 @@ swc_ecma_codegen = "=0.113.0"
 swc_atoms = "=0.2.13"
 anyhow = "=1.0.56"
 regex = "=1.5.5"
+heck = "=0.4.0"
 

--- a/crates/speedy-transform/src/types.rs
+++ b/crates/speedy-transform/src/types.rs
@@ -30,6 +30,8 @@ pub struct RepalceSpecConfig {
   pub replace_expr: JsFunction,
   pub ignore_es_component: Option<Vec<String>>,
   pub lower: Option<bool>,
+  pub camel2_dash_component_name: Option<bool>,
+  pub transform_to_default_import: Option<bool>,
 }
 
 #[napi(object)]
@@ -39,4 +41,5 @@ pub struct RepalceCssConfig {
   #[serde(skip_serializing)]
   pub replace_expr: JsFunction,
   pub lower: Option<bool>,
+  pub camel2_dash_component_name: Option<bool>,
 }

--- a/crates/speedy-transform/src/web_transform/babel_import.rs
+++ b/crates/speedy-transform/src/web_transform/babel_import.rs
@@ -60,16 +60,16 @@ pub fn transform_style(
             ImportSpecifier::Named(ref s) => {
               let imported = match &s.imported {
                 Some(imported) => match &imported {
-                  ModuleExportName::Ident(ident) => Option::Some(ident.sym.to_string()),
-                  ModuleExportName::Str(ident) => Option::Some(ident.value.to_string()),
+                  ModuleExportName::Ident(ident) => Some(ident.sym.to_string()),
+                  ModuleExportName::Str(ident) => Some(ident.value.to_string()),
                 },
-                None => Option::None,
+                None => None,
               };
               // 当 imported 不为 none 时, local.sym 是引入组件的 as 别名
               let as_name: Option<String> = if imported.is_some() {
-                Option::Some(s.local.sym.to_string())
+                Some(s.local.sym.to_string())
               } else {
-                Option::None
+                None
               };
               // 当 imported 不为 none 时, 实际引入的组件命名为 imported, 否则为 s.local.sym
               let ident: String = imported.unwrap_or(s.local.sym.to_string());
@@ -89,10 +89,7 @@ pub fn transform_style(
                   };
                   let mut need_replace = true;
                   if let Some(block_list) = ignore_component {
-                    need_replace = !block_list
-                      .iter()
-                      .map(|c| c.as_str())
-                      .any(|x| x == css_ident);
+                    need_replace = !block_list.iter().any(|x| x == &css_ident);
                   }
                   if need_replace {
                     let import_css_source = css
@@ -187,7 +184,7 @@ pub fn transform_style(
         vec![swc_ecma_ast::ImportSpecifier::Named(ImportNamedSpecifier {
           span: DUMMY_SP,
           imported: if js_source.as_name.is_some() {
-            Option::Some(swc_ecma_ast::ModuleExportName::Ident(swc_ecma_ast::Ident {
+            Some(swc_ecma_ast::ModuleExportName::Ident(swc_ecma_ast::Ident {
               span: DUMMY_SP,
               sym: JsWord::from(js_source.default_spec.as_str()),
               optional: false,

--- a/crates/speedy-transform/src/web_transform/babel_import.rs
+++ b/crates/speedy-transform/src/web_transform/babel_import.rs
@@ -1,16 +1,20 @@
 use crate::types::TransformConfig;
 use crate::web_transform::visit::IdentComponent;
+use heck::ToKebabCase;
 use napi::Env;
 use swc_atoms::JsWord;
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::{
-  Ident, ImportDecl, ImportDefaultSpecifier, ImportSpecifier, ModuleDecl, ModuleItem, Str,
+  Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier, ModuleDecl,
+  ModuleExportName, ModuleItem, Str,
 };
 use swc_ecma_visit::VisitWith;
 
 struct EsSpec {
   source: String,
   default_spec: String,
+  as_name: Option<String>,
+  use_default_import: bool,
 }
 
 pub fn transform_style(
@@ -54,20 +58,41 @@ pub fn transform_style(
         for specifier in &var.specifiers {
           match specifier {
             ImportSpecifier::Named(ref s) => {
-              let ident: String = s.local.sym.to_string();
+              let imported = match &s.imported {
+                Some(imported) => match &imported {
+                  ModuleExportName::Ident(ident) => Option::Some(ident.sym.to_string()),
+                  ModuleExportName::Str(ident) => Option::Some(ident.value.to_string()),
+                },
+                None => Option::None,
+              };
+              // 当 imported 不为 none 时, local.sym 是引入组件的 as 别名
+              let as_name: Option<String> = if imported.is_some() {
+                Option::Some(s.local.sym.to_string())
+              } else {
+                Option::None
+              };
+              // 当 imported 不为 none 时, 实际引入的组件命名为 imported, 否则为 s.local.sym
+              let ident: String = imported.unwrap_or(s.local.sym.to_string());
+
               if match_ident(&s.local) {
                 // 替换对应的 css
                 if let Some(ref css) = child_config.replace_css {
                   let ignore_component = &css.ignore_style_component;
                   let need_lower = css.lower.unwrap_or(false);
-                  let css_ident = if need_lower {
-                    ident.to_lowercase()
-                  } else {
-                    ident.clone()
+                  let camel2dash = css.camel2_dash_component_name.unwrap_or(true);
+                  let mut css_ident = ident.clone();
+                  if camel2dash {
+                    css_ident = css_ident.to_kebab_case();
+                  }
+                  if need_lower {
+                    css_ident = css_ident.to_lowercase()
                   };
                   let mut need_replace = true;
                   if let Some(block_list) = ignore_component {
-                    need_replace = !block_list.iter().map(|c| c.as_str()).any(|x| x == ident);
+                    need_replace = !block_list
+                      .iter()
+                      .map(|c| c.as_str())
+                      .any(|x| x == css_ident);
                   }
                   if need_replace {
                     let import_css_source = css
@@ -88,13 +113,18 @@ pub fn transform_style(
                 if let Some(ref js_config) = child_config.replace_js {
                   let ignore_component = &js_config.ignore_es_component;
                   let need_lower = js_config.lower.unwrap_or(false);
+                  let camel2dash = js_config.camel2_dash_component_name.unwrap_or(true);
+                  let use_default_import = js_config.transform_to_default_import.unwrap_or(true);
                   let mut js_ident = ident.clone();
+                  if camel2dash {
+                    js_ident = js_ident.to_kebab_case();
+                  }
                   if need_lower {
-                    js_ident = ident.to_lowercase();
+                    js_ident = js_ident.to_lowercase();
                   }
                   let mut need_replace = true;
                   if let Some(block_list) = ignore_component {
-                    need_replace = !block_list.iter().map(|c| c.as_str()).any(|x| x == ident);
+                    need_replace = !block_list.iter().map(|c| c.as_str()).any(|x| x == js_ident);
                   }
                   if need_replace {
                     let import_es_source = js_config
@@ -111,6 +141,8 @@ pub fn transform_style(
                     specifiers_es.push(EsSpec {
                       source: import_es_source,
                       default_spec: ident,
+                      as_name,
+                      use_default_import,
                     });
                     if !specifiers_rm_es.iter().any(|&c| c == item_index) {
                       specifiers_rm_es.push(item_index);
@@ -140,16 +172,37 @@ pub fn transform_style(
     let js_source_ref = js_source.source.as_str();
     let dec = ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
       span: DUMMY_SP,
-      specifiers: vec![swc_ecma_ast::ImportSpecifier::Default(
-        ImportDefaultSpecifier {
+      specifiers: if js_source.use_default_import {
+        vec![swc_ecma_ast::ImportSpecifier::Default(
+          ImportDefaultSpecifier {
+            span: DUMMY_SP,
+            local: swc_ecma_ast::Ident {
+              span: DUMMY_SP,
+              sym: JsWord::from(js_source.as_name.unwrap_or(js_source.default_spec).as_str()),
+              optional: false,
+            },
+          },
+        )]
+      } else {
+        vec![swc_ecma_ast::ImportSpecifier::Named(ImportNamedSpecifier {
           span: DUMMY_SP,
+          imported: if js_source.as_name.is_some() {
+            Option::Some(swc_ecma_ast::ModuleExportName::Ident(swc_ecma_ast::Ident {
+              span: DUMMY_SP,
+              sym: JsWord::from(js_source.default_spec.as_str()),
+              optional: false,
+            }))
+          } else {
+            None
+          },
           local: swc_ecma_ast::Ident {
             span: DUMMY_SP,
-            sym: JsWord::from(js_source.default_spec.as_str()),
+            sym: JsWord::from(js_source.as_name.unwrap_or(js_source.default_spec).as_str()),
             optional: false,
           },
-        },
-      )],
+          is_type_only: false,
+        })]
+      },
       src: Str {
         span: DUMMY_SP,
         value: JsWord::from(js_source_ref),

--- a/crates/speedy-transform/src/web_transform/babel_import.rs
+++ b/crates/speedy-transform/src/web_transform/babel_import.rs
@@ -79,7 +79,7 @@ pub fn transform_style(
                 if let Some(ref css) = child_config.replace_css {
                   let ignore_component = &css.ignore_style_component;
                   let need_lower = css.lower.unwrap_or(false);
-                  let camel2dash = css.camel2_dash_component_name.unwrap_or(true);
+                  let camel2dash = css.camel2_dash_component_name.unwrap_or(false);
                   let mut css_ident = ident.clone();
                   if camel2dash {
                     css_ident = css_ident.to_kebab_case();
@@ -89,7 +89,7 @@ pub fn transform_style(
                   };
                   let mut need_replace = true;
                   if let Some(block_list) = ignore_component {
-                    need_replace = !block_list.iter().any(|x| x == &css_ident);
+                    need_replace = !block_list.iter().any(|x| x == &ident);
                   }
                   if need_replace {
                     let import_css_source = css
@@ -110,7 +110,7 @@ pub fn transform_style(
                 if let Some(ref js_config) = child_config.replace_js {
                   let ignore_component = &js_config.ignore_es_component;
                   let need_lower = js_config.lower.unwrap_or(false);
-                  let camel2dash = js_config.camel2_dash_component_name.unwrap_or(true);
+                  let camel2dash = js_config.camel2_dash_component_name.unwrap_or(false);
                   let use_default_import = js_config.transform_to_default_import.unwrap_or(true);
                   let mut js_ident = ident.clone();
                   if camel2dash {
@@ -121,7 +121,7 @@ pub fn transform_style(
                   }
                   let mut need_replace = true;
                   if let Some(block_list) = ignore_component {
-                    need_replace = !block_list.iter().map(|c| c.as_str()).any(|x| x == js_ident);
+                    need_replace = !block_list.iter().any(|x| x == &ident);
                   }
                   if need_replace {
                     let import_es_source = js_config

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -8,7 +8,7 @@ import {transform} from '../lib';
 import * as process from "process";
 
 describe('speedy_napi_cases', function speedyTest() {
-    it('babel_import_transfrom with camel2DashComponentName default true', async () => {
+    it('babel_import_transfrom with camel2DashComponentName true', async () => {
         const code = `
 import React from "react";
 import ReactDOM from "react-dom";
@@ -71,6 +71,7 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
                         },
                         lower: true,
                         ignoreStyleComponent: undefined,
+                        camel2DashComponentName: true
                     },
                     replaceJs: {
                         replaceExpr: (ident: string) => {
@@ -78,6 +79,7 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
                         },
                         lower: true,
                         ignoreEsComponent: undefined,
+                        camel2DashComponentName: true
                     },
                 },
             ]
@@ -159,6 +161,7 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
                         },
                         lower: true,
                         ignoreStyleComponent: undefined,
+                        camel2DashComponentName: true,
                     },
                     replaceJs: {
                         replaceExpr: (ident: string) => {
@@ -167,6 +170,7 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
                         lower: true,
                         ignoreEsComponent: undefined,
                         transformToDefaultImport: false,
+                        camel2DashComponentName: true,
                     },
                 },
             ]

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -8,12 +8,13 @@ import {transform} from '../lib';
 import * as process from "process";
 
 describe('speedy_napi_cases', function speedyTest() {
-    it('babel_import_transfrom', async () => {
+    it('babel_import_transfrom with camel2DashComponentName default true', async () => {
         const code = `
 import React from "react";
 import ReactDOM from "react-dom";
-import { Button, Input } from "antd";
+import { Input, AutoComplete } from "antd";
 import Child from "./component/Child";
+import { Button as AntButton } from "antd";
 
 class Page extends React.Component<any,any> {
     render() {
@@ -21,7 +22,7 @@ class Page extends React.Component<any,any> {
             <div className={"test"}>
                 <div>Page</div>
                 <Child/>
-                <Button>click me</Button>
+                <AntButton>click me</AntButton>
                 <Input/>
             </div>
         );
@@ -32,10 +33,12 @@ ReactDOM.render(<Page/>, document.getElementById("root"));
 `;
 
         let target_code = `
-import "antd/es/input/style/index.css";
 import "antd/es/button/style/index.css";
+import "antd/es/auto-complete/style/index.css";
+import "antd/es/input/style/index.css";
+import AntButton from "antd/es/button/index.js";
+import AutoComplete from "antd/es/auto-complete/index.js";
 import Input from "antd/es/input/index.js";
-import Button from "antd/es/button/index.js";
 import React from "react";
 import ReactDOM from "react-dom";
 import Child from "./component/Child";
@@ -46,7 +49,7 @@ class Page extends React.Component{
             <div className={"test"}>
                 <div>Page</div>
                 <Child/>
-                <Button>click me</Button>
+                <AntButton>click me</AntButton>
                 <Input/>
             </div>
         );
@@ -75,6 +78,95 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
                         },
                         lower: true,
                         ignoreEsComponent: undefined,
+                    },
+                },
+            ]
+        })
+        console.timeEnd('babel_import_swc_transfrom');
+
+        // 执行同样的 babel 操作
+        console.time('babel_import_babeljs_transfrom');
+
+        const babel_res = babel_impl_bableimport(code, 'antd', `antd/es/{}/style/index.css`);
+        console.timeEnd('babel_import_babeljs_transfrom');
+
+        assert.equal(
+            target_code.replace(/\ +/g, '').replace(/[\r\n]/g, ''),
+            napi_res.code.replace(/\ +/g, '').replace(/[\r\n]/g, '')
+        );
+    });
+
+    it('babel_import_transfrom with transformToDefaultImport set false', async () => {
+        const code = `
+import React from "react";
+import ReactDOM from "react-dom";
+import { Input, AutoComplete } from "antd";
+import Child from "./component/Child";
+import { Button as AntButton } from "antd";
+
+class Page extends React.Component<any,any> {
+    render() {
+        return (
+            <div className={"test"}>
+                <div>Page</div>
+                <Child/>
+                <AntButton>click me</AntButton>
+                <Input/>
+            </div>
+        );
+    }
+}
+
+ReactDOM.render(<Page/>, document.getElementById("root"));
+`;
+
+        let target_code = `
+import "antd/es/button/style/index.css";
+import "antd/es/auto-complete/style/index.css";
+import "antd/es/input/style/index.css";
+import { Button as AntButton } from "antd/es/button/index.js";
+import { AutoComplete } from "antd/es/auto-complete/index.js";
+import { Input } from "antd/es/input/index.js";
+import React from "react";
+import ReactDOM from "react-dom";
+import Child from "./component/Child";
+
+class Page extends React.Component{
+    render() {
+        return (
+            <div className={"test"}>
+                <div>Page</div>
+                <Child/>
+                <AntButton>click me</AntButton>
+                <Input/>
+            </div>
+        );
+    }
+}
+
+ReactDOM.render(<Page / >, document.getElementById("root"));
+        `;
+        console.time('babel_import_swc_transfrom');
+        process.env["rsdebug"] = "info";
+        const napi_res = transform.transformBabelImport(code, {
+            reatRuntime: true,
+            babelImport: [
+                {
+                    fromSource: 'antd',
+                    replaceCss: {
+                        replaceExpr: (ident: string) => {
+                            return `antd/es/${ident}/style/index.css`;
+                        },
+                        lower: true,
+                        ignoreStyleComponent: undefined,
+                    },
+                    replaceJs: {
+                        replaceExpr: (ident: string) => {
+                            return `antd/es/${ident}/index.js`;
+                        },
+                        lower: true,
+                        ignoreEsComponent: undefined,
+                        transformToDefaultImport: false,
                     },
                 },
             ]

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -20,10 +20,13 @@ export interface RepalceSpecConfig {
   replaceExpr: (...args: any[]) => any
   ignoreEsComponent?: Array<string> | undefined | null
   lower?: boolean | undefined | null
+  camel2DashComponentName?: boolean | undefined | null
+  transformToDefaultImport?: boolean | undefined | null
 }
 export interface RepalceCssConfig {
   ignoreStyleComponent?: Array<string> | undefined | null
   replaceExpr: (...args: any[]) => any
   lower?: boolean | undefined | null
+  camel2DashComponentName?: boolean | undefined | null
 }
 export function transformBabelImport(code: string, config: TransformConfig, filename?: string | undefined | null, target?: string | undefined | null): TransformOutput


### PR DESCRIPTION
## Intro

this pr add two options "transform_to_default_import" and "camel2_dash_component_name".

It used like below example.

 ```ts
babelImport: [
    {
        fromSource: 'antd',
        replaceCss: {
            replaceExpr: (ident: string) => {
                return `antd/es/${ident}/style/index.css`;
            },
            lower: true,
            ignoreStyleComponent: undefined,
            // +++++++++++
            camel2DashComponentName: true // default true
        },
        replaceJs: {
            replaceExpr: (ident: string) => {
                return `antd/es/${ident}/index.js`;
            },
            lower: true,
            ignoreEsComponent: undefined,
            // +++++++++++
            transformToDefaultImport: false, // default true
            camel2DashComponentName: true // default true
        },
    }
]
```

- add support for importing as

```ts
import { Button as AntButton} from 'antd'
// ->
import AntButton from "antd/es/button/index.js";
```

- transformToDefaultImport

```ts
import { Button as AntButton } from 'antd'
// -> transformToDefaultImport: false
import { Button as AntButton } from "antd/es/button/index.js";
```

- camel2DashComponentName

```ts
import { AutoComplete } from 'antd'
// -> camel2DashComponentName: true
import AutoComplete from "antd/es/auto-complete/index.js";
```

## Why

This is because most component lib like antd has some component whose name like 'autoComplete', but it's real import path is 'auto-complete'. Although it can be solved by manualy adding some transform in replaceExpr, i think this transform is very common that worth to add an option.

On the other way, babel-plugin-import also has camel2DashComponentName and transformToDefaultImport options.