### PR TITLE
fix(speedy-transform): tree-shaking and ignore ts_type

### DIFF
--- a/crates/speedy-transform/src/web_transform/babel_import.rs
+++ b/crates/speedy-transform/src/web_transform/babel_import.rs
@@ -27,7 +27,6 @@ pub fn transform_style(
   let mut visitor = IdentComponent {
     component_name_jsx_ident: vec![],
     ident_list: vec![],
-    ts_type_ident_list: vec![],
   };
   module.body.visit_with(&mut visitor);
 
@@ -35,8 +34,7 @@ pub fn transform_style(
     let name = idnet.to_string().replace("#0", "");
     let mark = idnet.span.ctxt.as_u32();
     let item = (name, mark);
-    visitor.component_name_jsx_ident.contains(&item)
-      || (visitor.ident_list.contains(&item) && !visitor.ts_type_ident_list.contains(&item))
+    visitor.component_name_jsx_ident.contains(&item) || visitor.ident_list.contains(&item)
   };
 
   if project_config.babel_import.is_none()

--- a/crates/speedy-transform/src/web_transform/visit.rs
+++ b/crates/speedy-transform/src/web_transform/visit.rs
@@ -1,4 +1,4 @@
-use swc_ecma_ast::{Ident, JSXElement, JSXElementName, TsEntityName, TsTypeRef};
+use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName, TsEntityName, TsTypeRef};
 use swc_ecma_visit::Visit;
 use swc_ecma_visit::VisitWith;
 
@@ -14,6 +14,9 @@ pub struct IdentComponent {
 /// 增加 判断 jsx 所有引用的关系
 ///
 impl Visit for IdentComponent {
+  // need to skip import decl
+  fn visit_import_decl(&mut self, _: &ImportDecl) {}
+
   fn visit_jsx_element(&mut self, jsx: &JSXElement) {
     let mut compent_name = match &jsx.opening.name {
       JSXElementName::Ident(ident) => (ident.to_string(), ident.span.ctxt.as_u32()),
@@ -38,7 +41,7 @@ impl Visit for IdentComponent {
   fn visit_ts_type_ref(&mut self, ts_type: &TsTypeRef) {
     if let TsEntityName::Ident(ident) = &ts_type.type_name {
       self
-        .ident_list
+        .ts_type_ident_list
         .push((ident.sym.to_string(), ident.span.ctxt.as_u32()));
     }
   }

--- a/crates/speedy-transform/src/web_transform/visit.rs
+++ b/crates/speedy-transform/src/web_transform/visit.rs
@@ -1,4 +1,4 @@
-use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName, TsEntityName, TsTypeRef};
+use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName, TsTypeRef};
 use swc_ecma_visit::Visit;
 use swc_ecma_visit::VisitWith;
 
@@ -6,7 +6,6 @@ use swc_ecma_visit::VisitWith;
 pub struct IdentComponent {
   pub component_name_jsx_ident: Vec<(String, u32)>,
   pub ident_list: Vec<(String, u32)>,
-  pub ts_type_ident_list: Vec<(String, u32)>,
 }
 
 ///
@@ -38,11 +37,5 @@ impl Visit for IdentComponent {
       .push((ident.sym.to_string(), ident.span.ctxt.as_u32()));
   }
 
-  fn visit_ts_type_ref(&mut self, ts_type: &TsTypeRef) {
-    if let TsEntityName::Ident(ident) = &ts_type.type_name {
-      self
-        .ts_type_ident_list
-        .push((ident.sym.to_string(), ident.span.ctxt.as_u32()));
-    }
-  }
+  fn visit_ts_type_ref(&mut self, _: &TsTypeRef) {}
 }

--- a/crates/speedy-transform/src/web_transform/visit.rs
+++ b/crates/speedy-transform/src/web_transform/visit.rs
@@ -1,4 +1,5 @@
-use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName, TsTypeRef};
+use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName};
+use swc_ecma_visit::noop_visit_type;
 use swc_ecma_visit::Visit;
 use swc_ecma_visit::VisitWith;
 
@@ -37,5 +38,5 @@ impl Visit for IdentComponent {
       .push((ident.sym.to_string(), ident.span.ctxt.as_u32()));
   }
 
-  fn visit_ts_type_ref(&mut self, _: &TsTypeRef) {}
+  noop_visit_type!();
 }

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -24,6 +24,7 @@ class Page extends React.Component<any,any> {
                 <Child/>
                 <AntButton>click me</AntButton>
                 <Input/>
+                <AutoComplete />
             </div>
         );
     }
@@ -51,6 +52,7 @@ class Page extends React.Component{
                 <Child/>
                 <AntButton>click me</AntButton>
                 <Input/>
+                <AutoComplete />
             </div>
         );
     }
@@ -114,6 +116,7 @@ class Page extends React.Component<any,any> {
                 <Child/>
                 <AntButton>click me</AntButton>
                 <Input/>
+                <AutoComplete />
             </div>
         );
     }
@@ -140,6 +143,89 @@ class Page extends React.Component{
                 <div>Page</div>
                 <Child/>
                 <AntButton>click me</AntButton>
+                <Input/>
+                <AutoComplete />
+            </div>
+        );
+    }
+}
+
+ReactDOM.render(<Page / >, document.getElementById("root"));
+        `;
+        console.time('babel_import_swc_transfrom');
+        process.env["rsdebug"] = "info";
+        const napi_res = transform.transformBabelImport(code, {
+            reatRuntime: true,
+            babelImport: [
+                {
+                    fromSource: 'antd',
+                    replaceCss: {
+                        replaceExpr: (ident: string) => {
+                            return `antd/es/${ident}/style/index.css`;
+                        },
+                        lower: true,
+                        ignoreStyleComponent: undefined,
+                        camel2DashComponentName: true,
+                    },
+                    replaceJs: {
+                        replaceExpr: (ident: string) => {
+                            return `antd/es/${ident}/index.js`;
+                        },
+                        lower: true,
+                        ignoreEsComponent: undefined,
+                        transformToDefaultImport: false,
+                        camel2DashComponentName: true,
+                    },
+                },
+            ]
+        })
+        console.timeEnd('babel_import_swc_transfrom');
+
+        // 执行同样的 babel 操作
+        console.time('babel_import_babeljs_transfrom');
+
+        const babel_res = babel_impl_bableimport(code, 'antd', `antd/es/{}/style/index.css`);
+        console.timeEnd('babel_import_babeljs_transfrom');
+
+        assert.equal(
+            target_code.replace(/\ +/g, '').replace(/[\r\n]/g, ''),
+            napi_res.code.replace(/\ +/g, '').replace(/[\r\n]/g, '')
+        );
+    });
+
+    it('babel_import_transfrom should tree shaking (ts_type and unused components)', async () => {
+        const code = `
+import React from "react";
+import ReactDOM from "react-dom";
+import { Input, AutoComplete, InputProps } from "antd";
+import Child from "./component/Child";
+
+class Page extends React.Component<InputProps,any> {
+    render() {
+        return (
+            <div className={"test"}>
+                <div>Page</div>
+                <Input/>
+            </div>
+        );
+    }
+}
+
+ReactDOM.render(<Page/>, document.getElementById("root"));
+`;
+
+        let target_code = `
+import "antd/es/input/style/index.css";
+import { Input } from "antd/es/input/index.js";
+import React from "react";
+import ReactDOM from "react-dom";
+import Child from "./component/Child";
+
+class Page extends React.Component{
+    render() {
+        return (
+            <div className={"test"}>
+                <div>Page</div>
                 <Input/>
             </div>
         );


### PR DESCRIPTION
## Intro

Origin feat commit see [feat: support ts_type ignore with babel_import](https://github.com/speedy-js/speedy-native/commit/03c137866dfc5fc670768c73d59a35a038871321)

```rust
let match_ident = |idnet: &Ident| -> bool {
  let name = idnet.to_string().replace("#0", "");
  let mark = idnet.span.ctxt.as_u32();
  let item = (name, mark);
  visitor.component_name_jsx_ident.contains(&item)
    || (visitor.ident_list.contains(&item) && !visitor.ts_type_ident_list.contains(&item))
};
```

- This feature uses `ident_list` and `ts_type_ident_list` to ignore ts_type. But the previous code only push element to `ident_list`. It seems to be an error.
- `identifier` in `import_decl` shouldn't be pushed into `ident_list` because it don't used the component. We need to skip  `import_decl` ast travel