### PR TITLE
fix(speedy-transform): fix jsx_element name track

### DIFF
--- a/crates/speedy-transform/src/web_transform/visit.rs
+++ b/crates/speedy-transform/src/web_transform/visit.rs
@@ -1,4 +1,4 @@
-use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName};
+use swc_ecma_ast::{Ident, ImportDecl, JSXElement, JSXElementName, JSXObject};
 use swc_ecma_visit::noop_visit_type;
 use swc_ecma_visit::Visit;
 use swc_ecma_visit::VisitWith;
@@ -21,7 +21,19 @@ impl Visit for IdentComponent {
     let mut compent_name = match &jsx.opening.name {
       JSXElementName::Ident(ident) => (ident.to_string(), ident.span.ctxt.as_u32()),
       JSXElementName::JSXMemberExpr(member) => {
-        (member.prop.to_string(), member.prop.span.ctxt.as_u32())
+        let mut obj = &member.obj;
+        let real_ident;
+        loop {
+          match obj {
+            JSXObject::JSXMemberExpr(next) => obj = &next.obj,
+            JSXObject::Ident(ident) => {
+              real_ident = ident;
+              break;
+            }
+          }
+        }
+
+        (real_ident.to_string(), real_ident.span.ctxt.as_u32())
       }
       JSXElementName::JSXNamespacedName(space) => {
         (space.name.to_string(), space.name.span.ctxt.as_u32())

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -197,7 +197,7 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
         const code = `
 import React from "react";
 import ReactDOM from "react-dom";
-import { Input, AutoComplete, InputProps } from "antd";
+import { Input, AutoComplete, InputProps, Radio } from "antd";
 import Child from "./component/Child";
 
 class Page extends React.Component<InputProps,any> {
@@ -206,6 +206,7 @@ class Page extends React.Component<InputProps,any> {
             <div className={"test"}>
                 <div>Page</div>
                 <Input/>
+                <Radio.Group />
             </div>
         );
     }
@@ -215,7 +216,9 @@ ReactDOM.render(<Page/>, document.getElementById("root"));
 `;
 
         let target_code = `
+import "antd/es/radio/style/index.css";
 import "antd/es/input/style/index.css";
+import { Radio } from "antd/es/radio/index.js";
 import { Input } from "antd/es/input/index.js";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -227,6 +230,7 @@ class Page extends React.Component{
             <div className={"test"}>
                 <div>Page</div>
                 <Input/>
+                <Radio.Group />
             </div>
         );
     }


### PR DESCRIPTION
Origin code tracks the `props` of `JSXElementName::JSXMemberExpr`. But in fact, we should track the `obj` of that.

For example

```ts
class Page extends React.Component{
    render() {
        return (
            <div className={"test"}>
                <div>Page</div>
                <Input/>
                <Radio.Group /> // ref Radio, but not Group
            </div>
        );
    }
}
```