### PR TITLE
feat: add remove callexpr statement option

### DIFF
--- a/crates/speedy-transform/src/types.rs
+++ b/crates/speedy-transform/src/types.rs
@@ -11,6 +11,7 @@ pub struct TransformOutput {
 #[napi(object)]
 #[derive(Serialize)]
 pub struct TransformConfig {
+  pub remove_call: Option<Vec<String>>,
   pub react_runtime: Option<bool>,
   pub babel_import: Option<Vec<BabelImportConfig>>,
 }

--- a/crates/speedy-transform/src/web_transform/mod.rs
+++ b/crates/speedy-transform/src/web_transform/mod.rs
@@ -1,4 +1,5 @@
 pub mod babel_import;
 pub mod parser;
 pub mod react;
+pub mod remove_call;
 pub mod visit;

--- a/crates/speedy-transform/src/web_transform/parser.rs
+++ b/crates/speedy-transform/src/web_transform/parser.rs
@@ -1,6 +1,7 @@
 use crate::types::TransformConfig;
 use crate::web_transform::babel_import::transform_style;
 use crate::web_transform::react::transform_perfixreact;
+use crate::web_transform::remove_call::remove_call;
 use napi::Env;
 use swc::config::SourceMapsConfig;
 use swc::{Compiler, TransformOutput};
@@ -57,6 +58,7 @@ pub fn transform(
 
   transform_style(env, &mut module, &config);
   transform_perfixreact(&mut module, &config, code);
+  remove_call(&mut module, &config);
 
   let target_ref = target.unwrap_or_else(|| "".to_string());
   let swc_target = match target_ref.as_str() {

--- a/crates/speedy-transform/src/web_transform/remove_call.rs
+++ b/crates/speedy-transform/src/web_transform/remove_call.rs
@@ -1,0 +1,48 @@
+use swc_ecma_ast::{BlockStmt, Expr, Module};
+use swc_ecma_visit::{VisitMut, VisitMutWith};
+
+use crate::types::TransformConfig;
+
+struct RmCallStmt {
+  rm_calls: Vec<String>,
+}
+
+impl VisitMut for RmCallStmt {
+  fn visit_mut_block_stmt(&mut self, n: &mut BlockStmt) {
+    let mut rm_idx = vec![];
+    for (idx, stmt) in n.stmts.iter().enumerate() {
+      if let Some(Some(call_expr)) = stmt.as_expr().map(|expr_stmt| expr_stmt.expr.as_call()) {
+        if let Some(callee) = call_expr.callee.as_expr() {
+          let callee_name = match callee.as_ref() {
+            Expr::Member(member) => member
+              .prop
+              .as_ident()
+              .map_or("".to_string(), |ident| ident.sym.to_string()),
+            Expr::Ident(ident) => ident.sym.to_string(),
+            _ => "".to_string(),
+          };
+
+          if self.rm_calls.iter().any(|x| x == &callee_name) {
+            rm_idx.push(idx);
+          }
+        }
+      }
+    }
+    let mut index: usize = 0;
+    while let Some(i) = rm_idx.get(index) {
+      let rm_index = *i - index;
+      n.stmts.remove(rm_index);
+      index += 1;
+    }
+  }
+}
+
+pub fn remove_call(module: &mut Module, config: &TransformConfig) {
+  if config.remove_call.is_none() || config.remove_call.as_ref().unwrap().is_empty() {
+    return;
+  }
+
+  let rm_calls = config.remove_call.as_ref().unwrap().clone();
+  let mut visitor = RmCallStmt { rm_calls };
+  module.visit_mut_with(&mut visitor);
+}

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -366,6 +366,56 @@ ReactDOM.render(<Page / >, document.getElementById("root"));
             napi_res.code.replace(/\ +/g, '').replace(/[\r\n]/g, '')
         );
     });
+
+    it('remove_call_transform should work', async () => {
+        let code = `
+import React from 'react';
+import ReactDOM from "react-dom";
+import { useEffect } from 'react';
+import { useCustom } from '@/hooks'
+
+function App() {
+    const [num, setNum] = useState(1);
+    
+    React.useEffect(() => {
+        setNum(2);
+    }, [])
+
+    useEffect(() => {
+        setNum(3);
+    }, []);
+
+    useCustom();
+
+    return <div>{num}</div>;
+}
+ReactDOM.render(<Page/>, document.getElementById("root"));
+`;
+
+        let target_code = `
+import React from "react";
+import ReactDOM from "react-dom";
+import { useEffect } from "react";
+import { useCustom } from "@/hooks";
+
+function App() {
+    const [num, setNum] = useState(1);
+
+    return <div>{num}</div>;
+}
+
+ReactDOM.render(<Page/>, document.getElementById("root"));
+`;
+
+        const napi_res = transform.transformBabelImport(code, {
+            removeCall: ['useEffect', 'useCustom']
+        })
+
+        assert.equal(
+            target_code.replace(/\ +/g, '').replace(/[\r\n]/g, ''),
+            napi_res.code.replace(/\ +/g, '').replace(/[\r\n]/g, '')
+        );
+    })
 });
 
 /*

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -8,6 +8,7 @@ export interface TransformOutput {
   map?: string | undefined | null
 }
 export interface TransformConfig {
+  removeCall?: Array<string> | undefined | null
   reactRuntime?: boolean | undefined | null
   babelImport?: Array<BabelImportConfig> | undefined | null
 }


### PR DESCRIPTION
## Intro
A new feature that can remove some **callexpr statement**.

## Option

```rust
  pub struct TransformConfig {
+   pub remove_call: Option<Vec<String>>,
    pub react_runtime: Option<bool>,
    pub babel_import: Option<Vec<BabelImportConfig>>,
  }
```

## Example

Option

```ts
{
    ...
    remove_call: ['useEffect', 'useCustom']
    ...
}
```

will transform below code

```ts
function App() {
    const [num, setNum] = useState(1);
    React.useEffect(() => {
        setNum(2);
    }, [])
    useEffect(() => {
        setNum(3);
    }, []);
    useCustom();
    return <div>{num}</div>;
}
```

to this

```ts
function App() {
    const [num, setNum] = useState(1);
    return <div>{num}</div>;
}
```
