### PR TITLE
fix: make tsx parse a config (close #36)

### DIFF
--- a/crates/speedy-transform/src/napi_types.rs
+++ b/crates/speedy-transform/src/napi_types.rs
@@ -14,7 +14,7 @@ pub struct TransformConfig {
   pub remove_use_effect: Option<bool>,
   pub react_runtime: Option<bool>,
   pub babel_import: Option<Vec<BabelImportConfig>>,
-  pub tsx: Option<bool>,
+  pub code_type: Option<String>,
 }
 
 #[napi(object)]

--- a/crates/speedy-transform/src/napi_types.rs
+++ b/crates/speedy-transform/src/napi_types.rs
@@ -14,6 +14,7 @@ pub struct TransformConfig {
   pub remove_use_effect: Option<bool>,
   pub react_runtime: Option<bool>,
   pub babel_import: Option<Vec<BabelImportConfig>>,
+  pub tsx: Option<bool>,
 }
 
 #[napi(object)]

--- a/crates/speedy-transform/src/web_transform/parser.rs
+++ b/crates/speedy-transform/src/web_transform/parser.rs
@@ -10,7 +10,7 @@ use swc_common::sync::Lrc;
 use swc_common::{FileName, SourceMap};
 use swc_ecma_ast::{EsVersion, Module};
 use swc_ecma_parser::lexer::Lexer;
-use swc_ecma_parser::{Parser, Syntax, TsConfig};
+use swc_ecma_parser::{EsConfig, Parser, Syntax, TsConfig};
 
 pub fn transform_module(module: &mut Module, config: &TransformConfig, extra: &ExtraInfo) {
   transform_style(module, config, extra);
@@ -31,19 +31,37 @@ pub fn transform(
   let compiler = Compiler::new(cm);
 
   #[cfg(not(target_arch = "wasm32"))]
-  let tsx_parse = config.tsx.unwrap_or(true);
+  let code_type = config
+    .code_type
+    .as_ref()
+    .map_or("tsx".to_owned(), |code| code.to_lowercase());
   // wasm plugin parse option is in js side, not in rust side
   #[cfg(target_arch = "wasm32")]
-  let tsx_parse = true;
+  let code_type = "tsx".to_owned();
 
   let lexer = Lexer::new(
-    // We want to parse ecmascript
-    Syntax::Typescript(TsConfig {
-      tsx: tsx_parse,
-      decorators: true,
-      dts: false,
-      no_early_errors: false,
-    }),
+    match code_type.as_str() {
+      "js" => Syntax::Es(EsConfig {
+        jsx: false,
+        ..Default::default()
+      }),
+      "jsx" => Syntax::Es(EsConfig {
+        jsx: true,
+        ..Default::default()
+      }),
+      "ts" => Syntax::Typescript(TsConfig {
+        tsx: false,
+        decorators: true,
+        dts: false,
+        no_early_errors: false,
+      }),
+      _ => Syntax::Typescript(TsConfig {
+        tsx: true,
+        decorators: true,
+        dts: false,
+        no_early_errors: false,
+      }),
+    },
     // EsVersion defaults to es5
     EsVersion::Es2016,
     StringInput::from(&*fm),

--- a/crates/speedy-transform/src/web_transform/parser.rs
+++ b/crates/speedy-transform/src/web_transform/parser.rs
@@ -30,10 +30,16 @@ pub fn transform(
   let fm = cm.new_source_file(FileName::Custom(source_filename.clone()), code.into());
   let compiler = Compiler::new(cm);
 
+  #[cfg(not(target_arch = "wasm32"))]
+  let tsx_parse = config.tsx.unwrap_or(true);
+  // wasm plugin parse option is in js side, not in rust side
+  #[cfg(target_arch = "wasm32")]
+  let tsx_parse = true;
+
   let lexer = Lexer::new(
     // We want to parse ecmascript
     Syntax::Typescript(TsConfig {
-      tsx: true,
+      tsx: tsx_parse,
       decorators: true,
       dts: false,
       no_early_errors: false,

--- a/node/__tests__/__snapshots__/unit.spec.ts.snap
+++ b/node/__tests__/__snapshots__/unit.spec.ts.snap
@@ -221,3 +221,16 @@ function App() {
 ReactDOM.render(<Page />, document.getElementById(\\"root\\"));
 "
 `;
+
+exports[`speedy-napi: ts parse config can parse ts only syntax 1`] = `
+"import { useEffect, useState } from \\"react\\";
+function useCount() {
+    const [count, setCount] = useState(0);
+    return [
+        count,
+        setCount
+    ];
+}
+const useName = <[]>useCount();
+"
+`;

--- a/node/__tests__/__snapshots__/unit.spec.ts.snap
+++ b/node/__tests__/__snapshots__/unit.spec.ts.snap
@@ -123,6 +123,19 @@ ReactDOM.render(<Page />, document.getElementById(\\"root\\"));
 "
 `;
 
+exports[`speedy-napi: code type config can parse ts only syntax 1`] = `
+"import { useEffect, useState } from \\"react\\";
+function useCount() {
+    const [count, setCount] = useState(0);
+    return [
+        count,
+        setCount
+    ];
+}
+const useName = <[]>useCount();
+"
+`;
+
 exports[`speedy-napi: remove call remove_call source map test 1`] = `
 "import React from \\"react\\";
 import ReactDOM from \\"react-dom\\";
@@ -219,18 +232,5 @@ function App() {
     return <div >{num}</div>;
 }
 ReactDOM.render(<Page />, document.getElementById(\\"root\\"));
-"
-`;
-
-exports[`speedy-napi: ts parse config can parse ts only syntax 1`] = `
-"import { useEffect, useState } from \\"react\\";
-function useCount() {
-    const [count, setCount] = useState(0);
-    return [
-        count,
-        setCount
-    ];
-}
-const useName = <[]>useCount();
 "
 `;

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -483,7 +483,7 @@ ReactDOM.render(<Page/>, document.getElementById("root"));
   });
 });
 
-describe("speedy-napi: ts parse config", () => {
+describe("speedy-napi: code type config", () => {
   it("can parse ts only syntax", () => {
     // https://github.com/speedy-js/speedy-native/issues/36
     const code = `
@@ -503,7 +503,7 @@ const useName = <[]>useCount();
 
     const res = transform.transformBabelImport(code, {
       removeUseEffect: true,
-      tsx: false,
+      codeType: "ts",
     });
 
     expect(res.code).toMatchSnapshot();
@@ -528,7 +528,7 @@ const useName = <[]>useCount();
     expect(() =>
       transform.transformBabelImport(code, {
         removeUseEffect: true,
-        tsx: true,
+        codeType: "tsx",
       })
     ).toThrowErrorMatchingInlineSnapshot(
       `"Unexpected token \`[\`. Expected jsx identifier"`
@@ -556,6 +556,47 @@ const useName = <[]>useCount();`;
       })
     ).toThrowErrorMatchingInlineSnapshot(
       `"Unexpected token \`[\`. Expected jsx identifier"`
+    );
+  });
+
+  it("parse ts code will error if wrongly set js", () => {
+    const code = `
+import { useEffect } from "react";
+
+function useCount(): void {
+  useEffect(() => {
+  }, []);
+}
+
+const useName = useCount();
+`;
+
+    expect(() =>
+      transform.transformBabelImport(code, {
+        removeUseEffect: true,
+        codeType: "js",
+      })
+    ).toThrowErrorMatchingInlineSnapshot(`"Expected '{', got ':'"`);
+  });
+
+  it("parse jsx code will error if wrongly set js", () => {
+    const code = `
+import { useEffect } from "react";
+
+function useCount() {
+  return <div />
+}
+
+const useName = useCount();
+`;
+
+    expect(() =>
+      transform.transformBabelImport(code, {
+        removeUseEffect: true,
+        codeType: "js",
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected token \`>\`. Expected this, import, async, function, [ for array literal, { for object literal, @ for decorator, function, class, null, true, false, number, bigint, string, regexp, \` for template literal, (, or an identifier"`
     );
   });
 });

--- a/node/__tests__/unit.spec.ts
+++ b/node/__tests__/unit.spec.ts
@@ -482,3 +482,80 @@ ReactDOM.render(<Page/>, document.getElementById("root"));
     expect(position3.column).toMatchSnapshot();
   });
 });
+
+describe("speedy-napi: ts parse config", () => {
+  it("can parse ts only syntax", () => {
+    // https://github.com/speedy-js/speedy-native/issues/36
+    const code = `
+import { useEffect, useState } from "react";
+
+function useCount() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    console.log(count);
+  }, [count]);
+
+  return [count, setCount];
+}
+
+const useName = <[]>useCount();
+`;
+
+    const res = transform.transformBabelImport(code, {
+      removeUseEffect: true,
+      tsx: false,
+    });
+
+    expect(res.code).toMatchSnapshot();
+  });
+
+  it("parse will error if wrongly set tsx", () => {
+    const code = `
+import { useEffect, useState } from "react";
+
+function useCount() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    console.log(count);
+  }, [count]);
+
+  return [count, setCount];
+}
+
+const useName = <[]>useCount();
+`;
+
+    expect(() =>
+      transform.transformBabelImport(code, {
+        removeUseEffect: true,
+        tsx: true,
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected token \`[\`. Expected jsx identifier"`
+    );
+  });
+
+  it("default will parse tsx", () => {
+    const code = `
+import { useEffect, useState } from "react";
+
+function useCount() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    console.log(count);
+  }, [count]);
+
+  return [count, setCount];
+}
+
+const useName = <[]>useCount();`;
+
+    expect(() =>
+      transform.transformBabelImport(code, {
+        removeUseEffect: true,
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected token \`[\`. Expected jsx identifier"`
+    );
+  });
+});

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -11,6 +11,7 @@ export interface TransformConfig {
   removeUseEffect?: boolean | undefined | null
   reactRuntime?: boolean | undefined | null
   babelImport?: Array<BabelImportConfig> | undefined | null
+  tsx?: boolean | undefined | null
 }
 export interface BabelImportConfig {
   fromSource: string

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -11,7 +11,7 @@ export interface TransformConfig {
   removeUseEffect?: boolean | undefined | null
   reactRuntime?: boolean | undefined | null
   babelImport?: Array<BabelImportConfig> | undefined | null
-  tsx?: boolean | undefined | null
+  codeType?: string | undefined | null
 }
 export interface BabelImportConfig {
   fromSource: string


### PR DESCRIPTION
Bug see [https://github.com/speedy-js/speedy-native/issues/36](https://github.com/speedy-js/speedy-native/issues/36).

## Code

-  add a config `tsx: Option<bool>`.
- when `tsx` is `false`, swc only parse typescript, no tsx.
- add some test case